### PR TITLE
Change default time interval to 5 minutes.

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -48,7 +48,7 @@ NSString* const kSelfControlErrorDomain = @"SelfControlErrorDomain";
                                  [NSNumber numberWithBool: YES], @"BadgeApplicationIcon",
                                  [NSNumber numberWithBool: YES], @"AllowLocalNetworks",
                                  [NSNumber numberWithInt: 1440], @"MaxBlockLength",
-                                 [NSNumber numberWithInt: 15], @"BlockLengthInterval",
+                                 [NSNumber numberWithInt: 5], @"BlockLengthInterval",
                                  [NSNumber numberWithBool: NO], @"WhitelistAlertSuppress",
                                  nil];
     


### PR DESCRIPTION
How about changing the slider interval to 5 minutes ? It would be great if one could block unwanted websites for the duration of one [pomodoro session](http://en.wikipedia.org/wiki/Pomodoro_Technique) which typically is 25 minutes.
