### PR TITLE
centers timer label on yosemite fix for #233

### DIFF
--- a/TimerWindowController.m
+++ b/TimerWindowController.m
@@ -163,6 +163,7 @@
 	 ];
 
 	[timerLabel_ sizeToFit];
+	[timerLabel_ setFrame:NSRectFromCGRect(CGRectMake(0, timerLabel_.frame.origin.y, self.window.frame.size.width, timerLabel_.frame.size.height))];
 	[self resetStrikes];
 
 	if([[NSUserDefaults standardUserDefaults] boolForKey: @"BadgeApplicationIcon"]) {


### PR DESCRIPTION
a quick fix for #233 . I was unable to test on 10.9 but it should be safe. 