### PR TITLE
Fixes bug that prevents SelfControl to run from command line because …

### DIFF
--- a/HelperMain.m
+++ b/HelperMain.m
@@ -177,8 +177,8 @@ int main(int argc, char* argv[]) {
 			// settings.
 			NSDictionary* lockDictionary = @{@"HostBlacklist": defaults[@"HostBlacklist"],
 											 @"BlockDuration": defaults[@"BlockDuration"],
-											 @"BlockStartedDate": defaults[@"BlockStartedDate"],
-											 @"BlockAsWhitelist": defaults[@"BlockAsWhitelist"]};
+											 @"BlockStartedDate": [NSDate date],
+											 @"BlockAsWhitelist": defaults[@"BlockAsWhitelist"]};            
 			if([lockDictionary[@"HostBlacklist"] count] <= 0 || [lockDictionary[@"BlockDuration"] intValue] < 1
 			   || lockDictionary[@"BlockStartedDate"] == nil
 			   || [lockDictionary[@"BlockStartedDate"] isEqualToDate: [NSDate distantFuture]]) {


### PR DESCRIPTION
…of "Not enough block information".
Please have a look at https://github.com/SelfControlApp/selfcontrol/issues/284.

With this change it is possible to run SelfControl from command line, otherwise the following error occurs:
```2015-12-01 11:49:46.770 org.eyebeam.SelfControl[1917:285233] ERROR: Not enough block information.```
I hope this helps.