### PR TITLE
Sets BlockStartedDate also if the helper utility was started directly

### DIFF
--- a/HelperMain.m
+++ b/HelperMain.m
@@ -177,8 +177,8 @@ int main(int argc, char* argv[]) {
 			// settings.
 			NSDictionary* lockDictionary = @{@"HostBlacklist": defaults[@"HostBlacklist"],
 											 @"BlockDuration": defaults[@"BlockDuration"],
-											 @"BlockStartedDate": [NSDate date],
-											 @"BlockAsWhitelist": defaults[@"BlockAsWhitelist"]};            
+											 @"BlockStartedDate": defaults[@"BlockStartedDate"],
+											 @"BlockAsWhitelist": defaults[@"BlockAsWhitelist"]};
 			if([lockDictionary[@"HostBlacklist"] count] <= 0 || [lockDictionary[@"BlockDuration"] intValue] < 1
 			   || lockDictionary[@"BlockStartedDate"] == nil
 			   || [lockDictionary[@"BlockStartedDate"] isEqualToDate: [NSDate distantFuture]]) {

--- a/HelperMain.m
+++ b/HelperMain.m
@@ -170,6 +170,11 @@ int main(int argc, char* argv[]) {
 				printStatus(-209);
 				exit(EX_IOERR);
 			}
+            
+            // Update BlockStartedDate as the helper utility was probably started by command line and not through the AppController.
+            if(defaults[@"BlockStartedDate"] != nil && [defaults[@"BlockStartedDate"] isEqualToDate: [NSDate distantFuture]]){
+                setDefaultsValue(@"BlockStartedDate", [NSDate date], controllingUID);
+            }
 
 			NSDictionary* defaults = getDefaultsDict(controllingUID);
 			// In this case it doesn't make any sense to use an existing lock file (in

--- a/HelperMain.m
+++ b/HelperMain.m
@@ -177,8 +177,8 @@ int main(int argc, char* argv[]) {
 			// settings.
 			NSDictionary* lockDictionary = @{@"HostBlacklist": defaults[@"HostBlacklist"],
 											 @"BlockDuration": defaults[@"BlockDuration"],
-											 @"BlockStartedDate": defaults[@"BlockStartedDate"],
-											 @"BlockAsWhitelist": defaults[@"BlockAsWhitelist"]};
+											 @"BlockStartedDate": [NSDate date],
+											 @"BlockAsWhitelist": defaults[@"BlockAsWhitelist"]};            
 			if([lockDictionary[@"HostBlacklist"] count] <= 0 || [lockDictionary[@"BlockDuration"] intValue] < 1
 			   || lockDictionary[@"BlockStartedDate"] == nil
 			   || [lockDictionary[@"BlockStartedDate"] isEqualToDate: [NSDate distantFuture]]) {


### PR DESCRIPTION
If the helper utility is started directly, it now automatically sets the BlockStartedDate to the current date/time. 
With this small change it is possible to start SelfControl from command line without the problems that were described in https://github.com/SelfControlApp/selfcontrol/issues/284.
