### PR TITLE
Fix Chinese name displayed for English locale

### DIFF
--- a/zh-Hans.lproj/InfoPlist.strings
+++ b/zh-Hans.lproj/InfoPlist.strings
@@ -1,1 +1,2 @@
 CFBundleDisplayName="自我控制";
+CFBundleName="自我控制";


### PR DESCRIPTION
Adhere to Apple guidelines for localizing `CFBundleDisplayName ` (https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-110725)

> CFBundleDisplayName (String - iOS, macOS) specifies the display name of the bundle, visible to users and used by Siri. If you support localized names for your bundle, include this key in your app’s Info.plist file and in the InfoPlist.strings files of your app’s language subdirectories. If you localize this key, include a localized version of the CFBundleName key as well.