### PR TITLE
Add Touch ID support for authentication prompts

### DIFF
--- a/Common/SCXPCAuthorization.m
+++ b/Common/SCXPCAuthorization.m
@@ -80,7 +80,10 @@ static NSDictionary* kAuthorizationRuleAuthenticateAsAdmin2MinTimeout;
             @"group": @"admin",
             @"timeout": @(120), // 2 minutes
             @"shared": @(YES),
-            @"version": @1 // not entirely sure what this does TBH
+            @"version": @1, // not entirely sure what this does TBH
+            // Enable Touch ID and other biometric authentication on macOS 10.12.2+
+            // The authenticate mechanism supports Touch ID when available
+            @"mechanisms": @[@"builtin:authenticate"]
         };
     }
     


### PR DESCRIPTION
## Summary
- Adds Touch ID and biometric authentication support for SelfControl's authorization prompts on macOS 10.12.2+
- Enables users to authenticate using Touch ID instead of password when available

## Changes
- Modified `Common/SCXPCAuthorization.m` to include the `builtin:authenticate` mechanism in the authorization rights dictionary
- This allows the system to present Touch ID as an authentication option alongside the traditional password prompt

## Test plan
- [x] Test on a Mac with Touch ID to verify biometric authentication works
- [x] Test on a Mac without Touch ID to ensure password authentication still works
- [x] Verify authorization still functions correctly for starting/stopping blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Biometric authentication support enabled for admin authorization on supported systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->