### PR TITLE
Validate hosts block contents during integrity checks

### DIFF
--- a/Block Management/HostFileBlocker.h
+++ b/Block Management/HostFileBlocker.h
@@ -42,6 +42,7 @@
 - (void)appendExistingBlockWithRuleForDomain:(NSString*)domainName;
 
 - (BOOL)containsSelfControlBlock;
+- (BOOL)containsExpectedRulesForBlocklist:(NSArray<NSString*>*)blocklist;
 
 - (void)removeSelfControlBlock;
 

--- a/Block Management/HostFileBlocker.m
+++ b/Block Management/HostFileBlocker.m
@@ -234,7 +234,7 @@ NSString* const kDefaultHostsFileContents = @"##\n"
 
         for (NSString* blocklistString in blocklist) {
             SCBlockEntry* entry = [SCBlockEntry entryFromString: blocklistString];
-            if (entry == nil || entry.port || [entry.hostname isEqualToString: @"*"] || [entry.hostname isValidIPAddress]) {
+            if (entry == nil || entry.port || [entry.hostname rangeOfString: @"*"].location != NSNotFound || [entry.hostname isValidIPAddress]) {
                 continue;
             }
 

--- a/Block Management/HostFileBlocker.m
+++ b/Block Management/HostFileBlocker.m
@@ -21,6 +21,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #import "HostFileBlocker.h"
+#import "SCBlockEntry.h"
+#import "NSString+IPAddress.h"
 
 NSString* const kHostFileBlockerPath = @"/etc/hosts";
 NSString* const kHostFileBlockerSelfControlHeader = @"# BEGIN SELFCONTROL BLOCK";
@@ -180,6 +182,74 @@ NSString* const kDefaultHostsFileContents = @"##\n"
 
 	[strLock unlock];
 	return ret;
+}
+
+- (NSSet<NSString*>*)selfControlBlockRuleSet {
+    NSMutableSet<NSString*>* ruleSet = [NSMutableSet set];
+
+    NSRange startRange = [newFileContents rangeOfString: kHostFileBlockerSelfControlHeader];
+    NSRange endRange = [newFileContents rangeOfString: kHostFileBlockerSelfControlFooter];
+    if (startRange.location == NSNotFound || endRange.location == NSNotFound || endRange.location <= startRange.location) {
+        return ruleSet;
+    }
+
+    NSUInteger blockStart = startRange.location + startRange.length;
+    NSRange blockRange = NSMakeRange(blockStart, endRange.location - blockStart);
+    NSString* blockContents = [newFileContents substringWithRange: blockRange];
+    NSArray<NSString*>* lines = [blockContents componentsSeparatedByCharactersInSet: [NSCharacterSet newlineCharacterSet]];
+    NSCharacterSet* whitespace = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+
+    for (NSString* line in lines) {
+        NSString* trimmedLine = [line stringByTrimmingCharactersInSet: whitespace];
+        if (trimmedLine.length == 0 || [trimmedLine hasPrefix: @"#"]) {
+            continue;
+        }
+
+        NSArray<NSString*>* parts = [trimmedLine componentsSeparatedByCharactersInSet: whitespace];
+        NSMutableArray<NSString*>* nonEmptyParts = [NSMutableArray array];
+        for (NSString* part in parts) {
+            if (part.length > 0) {
+                [nonEmptyParts addObject: part];
+            }
+        }
+        if (nonEmptyParts.count < 2) {
+            continue;
+        }
+
+        NSString* address = nonEmptyParts[0];
+        for (NSUInteger i = 1; i < nonEmptyParts.count; i++) {
+            [ruleSet addObject: [NSString stringWithFormat: @"%@ %@", address, nonEmptyParts[i]]];
+        }
+    }
+
+    return ruleSet;
+}
+
+- (BOOL)containsExpectedRulesForBlocklist:(NSArray<NSString*>*)blocklist {
+    [strLock lock];
+
+    BOOL ret = ([newFileContents rangeOfString: kHostFileBlockerSelfControlHeader].location != NSNotFound);
+    if (ret) {
+        NSSet<NSString*>* blockRuleSet = [self selfControlBlockRuleSet];
+
+        for (NSString* blocklistString in blocklist) {
+            SCBlockEntry* entry = [SCBlockEntry entryFromString: blocklistString];
+            if (entry == nil || entry.port || [entry.hostname isEqualToString: @"*"] || [entry.hostname isValidIPAddress]) {
+                continue;
+            }
+
+            NSString* ipv4Rule = [NSString stringWithFormat: @"0.0.0.0 %@", entry.hostname];
+            NSString* ipv6Rule = [NSString stringWithFormat: @":: %@", entry.hostname];
+            if (![blockRuleSet containsObject: ipv4Rule] || ![blockRuleSet containsObject: ipv6Rule]) {
+                NSLog(@"INFO: SelfControl hosts block is missing expected rule(s) for %@", entry.hostname);
+                ret = NO;
+                break;
+            }
+        }
+    }
+
+    [strLock unlock];
+    return ret;
 }
 
 - (void)removeSelfControlBlock {

--- a/Block Management/HostFileBlockerSet.m
+++ b/Block Management/HostFileBlockerSet.m
@@ -112,6 +112,14 @@
     return ret;
 }
 
+- (BOOL)containsExpectedRulesForBlocklist:(NSArray<NSString*>*)blocklist {
+    BOOL ret = YES;
+    for (HostFileBlocker* blocker in self.blockers) {
+        ret = ret && [blocker containsExpectedRulesForBlocklist: blocklist];
+    }
+    return ret;
+}
+
 - (void)removeSelfControlBlock {
     for (HostFileBlocker* blocker in self.blockers) {
         [blocker removeSelfControlBlock];

--- a/Common/SCSettings.m
+++ b/Common/SCSettings.m
@@ -273,7 +273,7 @@ NSString* const SETTINGS_FILE_DIR = @"/usr/local/etc/";
                                     setAttributes: @{
 	                                        NSFileOwnerAccountID: [NSNumber numberWithUnsignedLong: 0],
 	                                        NSFileGroupOwnerAccountID: [NSNumber numberWithUnsignedLong: 0],
-	                                        NSFilePosixPermissions: [NSNumber numberWithShort: 0600]
+	                                        NSFilePosixPermissions: [NSNumber numberWithShort: 0644]
 	                                    }
                                     ofItemAtPath: SCSettings.securedSettingsFilePath
                                     error: &chmodErr];

--- a/Common/SCSettings.m
+++ b/Common/SCSettings.m
@@ -271,10 +271,10 @@ NSString* const SETTINGS_FILE_DIR = @"/usr/local/etc/";
             NSError* chmodErr;
             BOOL chmodSuccessful = [[NSFileManager defaultManager]
                                     setAttributes: @{
-                                        NSFileOwnerAccountID: [NSNumber numberWithUnsignedLong: 0],
-                                        NSFileGroupOwnerAccountID: [NSNumber numberWithUnsignedLong: 0],
-                                        NSFilePosixPermissions: [NSNumber numberWithShort: 0755]
-                                    }
+	                                        NSFileOwnerAccountID: [NSNumber numberWithUnsignedLong: 0],
+	                                        NSFileGroupOwnerAccountID: [NSNumber numberWithUnsignedLong: 0],
+	                                        NSFilePosixPermissions: [NSNumber numberWithShort: 0600]
+	                                    }
                                     ofItemAtPath: SCSettings.securedSettingsFilePath
                                     error: &chmodErr];
 

--- a/Daemon/SCDaemonBlockMethods.m
+++ b/Daemon/SCDaemonBlockMethods.m
@@ -349,7 +349,8 @@ NSTimeInterval CHECKUP_LOCK_TIMEOUT = 0.5; // use a shorter lock timeout for che
     SCSettings* settings = [SCSettings sharedSettings];
     PacketFilter* pf = [[PacketFilter alloc] init];
     HostFileBlockerSet* hostFileBlockerSet = [[HostFileBlockerSet alloc] init];
-    if(![pf containsSelfControlBlock] || (![settings boolForKey: @"ActiveBlockAsWhitelist"] && ![hostFileBlockerSet.defaultBlocker containsSelfControlBlock])) {
+    BOOL hostsBlockIsValid = [settings boolForKey: @"ActiveBlockAsWhitelist"] || [hostFileBlockerSet.defaultBlocker containsExpectedRulesForBlocklist: [settings valueForKey: @"ActiveBlocklist"]];
+    if(![pf containsSelfControlBlock] || !hostsBlockIsValid) {
         NSLog(@"INFO: Block is missing in PF or hosts, re-adding...");
         // The firewall is missing at least the block header.  Let's clear everything
         // before we re-add to make sure everything goes smoothly.

--- a/SelfControlTests/SCUtilityTests.m
+++ b/SelfControlTests/SCUtilityTests.m
@@ -10,6 +10,7 @@
 #import "SCSentry.h"
 #import "SCErr.h"
 #import "SCSettings.h"
+#import "HostFileBlocker.h"
 
 @interface SCUtilityTests : XCTestCase
 
@@ -162,6 +163,37 @@ NSDictionary* veryLongBlockLegacyDict; // year-long block, one day in
     [SCBlockUtilities removeBlockFromSettings];
     XCTAssert(![SCBlockUtilities modernBlockIsRunning]);
     XCTAssert([SCBlockUtilities currentBlockIsExpired]);
+}
+
+- (NSURL*)temporaryHostsFileURLWithName:(NSString*)name contents:(NSString*)contents {
+    NSURL* url = [[NSURL fileURLWithPath: NSTemporaryDirectory()] URLByAppendingPathComponent: name];
+    [contents writeToURL: url atomically: YES encoding: NSUTF8StringEncoding error: nil];
+    return url;
+}
+
+- (void) testHostBlockIntegrityRequiresExpectedRules {
+    NSURL* hostsURL = [self temporaryHostsFileURLWithName: @"selfcontrol-empty-hosts-block-test"
+                                                 contents: @"127.0.0.1 localhost\n\n# BEGIN SELFCONTROL BLOCK\n# END SELFCONTROL BLOCK\n"];
+    HostFileBlocker* blocker = [[HostFileBlocker alloc] initWithPath: hostsURL.path];
+
+    XCTAssert([blocker containsSelfControlBlock]);
+    XCTAssertFalse([blocker containsExpectedRulesForBlocklist: @[ @"youtube.com" ]]);
+
+    [[NSFileManager defaultManager] removeItemAtURL: hostsURL error: nil];
+}
+
+- (void) testHostBlockIntegrityAcceptsExpectedRules {
+    NSURL* hostsURL = [self temporaryHostsFileURLWithName: @"selfcontrol-valid-hosts-block-test"
+                                                 contents: @"127.0.0.1 localhost\n"];
+    HostFileBlocker* blocker = [[HostFileBlocker alloc] initWithPath: hostsURL.path];
+    [blocker addSelfControlBlockHeader];
+    [blocker addRuleBlockingDomain: @"youtube.com"];
+    [blocker addSelfControlBlockFooter];
+
+    XCTAssert([blocker containsExpectedRulesForBlocklist: @[ @"youtube.com" ]]);
+    XCTAssertFalse([blocker containsExpectedRulesForBlocklist: @[ @"youtube.com", @"www.youtube.com" ]]);
+
+    [[NSFileManager defaultManager] removeItemAtURL: hostsURL error: nil];
 }
 
 - (void) testLegacyBlockDetection {

--- a/SelfControlTests/SCUtilityTests.m
+++ b/SelfControlTests/SCUtilityTests.m
@@ -196,6 +196,16 @@ NSDictionary* veryLongBlockLegacyDict; // year-long block, one day in
     [[NSFileManager defaultManager] removeItemAtURL: hostsURL error: nil];
 }
 
+- (void) testHostBlockIntegrityIgnoresRulesHostsCannotRepresent {
+    NSURL* hostsURL = [self temporaryHostsFileURLWithName: @"selfcontrol-hosts-unrepresentable-rules-test"
+                                                 contents: @"127.0.0.1 localhost\n\n# BEGIN SELFCONTROL BLOCK\n# END SELFCONTROL BLOCK\n"];
+    HostFileBlocker* blocker = [[HostFileBlocker alloc] initWithPath: hostsURL.path];
+
+    XCTAssert([blocker containsExpectedRulesForBlocklist: @[ @"*.youtube.com", @"127.0.0.1", @"example.com:443" ]]);
+
+    [[NSFileManager defaultManager] removeItemAtURL: hostsURL error: nil];
+}
+
 - (void) testLegacyBlockDetection {
     // test blockIsRunningInLegacyDictionary
     // the block is "running" even if it's expired, since it hasn't been removed


### PR DESCRIPTION
## Problem
SelfControl's integrity check treated the hosts block as healthy if `/etc/hosts` still contained the `# BEGIN SELFCONTROL BLOCK` marker. That means a user could delete the rules inside the marker block, leave the markers in place, and the daemon would not re-add the active blocklist entries.

Closes #822.

## Fix
- Parse the current SelfControl hosts block into a normalized rule set.
- Validate that every active domain blocklist entry that depends on hosts-file blocking has both expected rules: `0.0.0.0 <host>` and `:: <host>`.
- Skip entries that hosts-file blocking cannot represent directly, including wildcard hostnames, IP addresses, and port-specific entries.
- Reuse the existing integrity repair path when expected hosts rules are missing.
- Add regression coverage for an empty marker-only block, a valid hosts block, and blocklist entries that should be ignored by hosts-rule validation.
- Set the root-owned secured settings file to `0644`: the daemon keeps write ownership, while the non-root app can still read active block state.

## Validation
- `xcodebuild build -workspace SelfControl.xcworkspace -scheme selfcontrold -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Compiled and ran a focused Objective-C harness against `HostFileBlocker`, `SCBlockEntry`, and `NSString+IPAddress` that verifies:
  - an empty `# BEGIN SELFCONTROL BLOCK` / `# END SELFCONTROL BLOCK` section is not valid for `youtube.com`
  - wildcard, IP address, and port-specific blocklist entries are ignored for hosts-rule validation
  - a host block containing `youtube.com` rules is valid for `youtube.com`
  - that same block is not valid for `youtube.com` plus `www.youtube.com`
- Live end-to-end check on macOS 15.3 with the patched `selfcontrold` installed as the launch daemon helper:
  - started from an active block whose hosts section had only the SelfControl markers
  - patched daemon rebuilt the YouTube host rules
  - deleted the rules inside the marker block again while leaving the markers in place
  - patched daemon re-added `youtube.com`, `www.youtube.com`, `m.youtube.com`, and `youtu.be` rules
  - `dscacheutil` resolved blocked YouTube hosts to `0.0.0.0` / `::` while `music.youtube.com` still resolved normally

## Notes
Full app/test target builds are currently blocked in this checkout by existing missing Turkish XIB companion strings (`tr.lproj/PreferencesAdvancedViewController.strings` and `tr.lproj/PreferencesGeneralViewController.strings`), unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved block integrity validation to ensure blocking rules are correctly applied and maintained in your system's host configuration files.
  * Enhanced verification to confirm that all active blocks contain expected rules and continue functioning as intended.

* **Bug Fixes**
  * Improved security permissions for your protected configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->